### PR TITLE
Feat : 업체등록 게시물 수정 삭제 추가

### DIFF
--- a/src/main/java/com/sparta/petplace/exception/enumclass/Error.java
+++ b/src/main/java/com/sparta/petplace/exception/enumclass/Error.java
@@ -27,6 +27,7 @@ public enum Error {
 
     // S3
     FAIL_S3_SAVE("400", "S3파일 저장 중 예외 발생"),
+    FAIL_S3_DELETE("400","S3파일 삭제 중 예외 발생"),
     DELETE_S3_FILE("400","s3에 저장되었던 파일 삭제"),
     WRONG_IMAGE_FORMAT("400", "잘못된 포멧입니다."),
     WRONG_INPUT_CONTEN("400", "파일이 존재하지 않습니다."),

--- a/src/main/java/com/sparta/petplace/like/repository/LikesRepository.java
+++ b/src/main/java/com/sparta/petplace/like/repository/LikesRepository.java
@@ -11,4 +11,7 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     Optional<Likes> findByPostAndMember(Post post, Member member);
 
     Likes findByPostIdAndMember(Long post_id , Member member);
+
+    void deleteByPostId(Long postId);
 }
+

--- a/src/main/java/com/sparta/petplace/member/controller/MemberController.java
+++ b/src/main/java/com/sparta/petplace/member/controller/MemberController.java
@@ -24,7 +24,6 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members")
 @Slf4j
 public class MemberController {
 

--- a/src/main/java/com/sparta/petplace/mypage/repository/MypageRepository.java
+++ b/src/main/java/com/sparta/petplace/mypage/repository/MypageRepository.java
@@ -8,4 +8,7 @@ import java.util.List;
 
 public interface MypageRepository extends JpaRepository<Mypage,Long> {
     List<Mypage> findByMemberId(Long id);
+
+    void deleteByPostId(Long postId);
+
 }

--- a/src/main/java/com/sparta/petplace/post/controller/PostController.java
+++ b/src/main/java/com/sparta/petplace/post/controller/PostController.java
@@ -3,6 +3,8 @@ package com.sparta.petplace.post.controller;
 
 import com.sparta.petplace.auth.security.UserDetailsImpl;
 import com.sparta.petplace.common.ApiResponseDto;
+import com.sparta.petplace.common.ErrorResponse;
+import com.sparta.petplace.common.SuccessResponse;
 import com.sparta.petplace.post.RequestDto.PostRequestDto;
 import com.sparta.petplace.post.ResponseDto.PostResponseDto;
 import com.sparta.petplace.post.service.PostService;
@@ -34,8 +36,18 @@ public class PostController {
    }
 
    @GetMapping("/posts/{post_id}")
-   private PostResponseDto getPostId(@PathVariable Long post_id ,@AuthenticationPrincipal UserDetailsImpl userDetails){
+   public PostResponseDto getPostId(@PathVariable Long post_id ,@AuthenticationPrincipal UserDetailsImpl userDetails){
       return postService.getPostId(post_id,userDetails.getMember());
+   }
+
+   @PatchMapping("/posts/{post_id}")
+   public ApiResponseDto<?> updePost(@PathVariable Long post_id , PostRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
+      return postService.updatePost(post_id,requestDto,userDetails.getMember());
+   }
+
+   @DeleteMapping("/posts/{post_id}")
+   public ApiResponseDto<SuccessResponse> deletePost(@PathVariable Long post_id, @AuthenticationPrincipal UserDetailsImpl userDetails){
+      return postService.deletePost(post_id, userDetails.getMember());
    }
 
 

--- a/src/main/java/com/sparta/petplace/post/entity/Post.java
+++ b/src/main/java/com/sparta/petplace/post/entity/Post.java
@@ -68,4 +68,18 @@ public class Post extends Timestamped {
                 member(member).
                 build();
     }
+
+    public void update(PostRequestDto requestDto , List<PostImage> image) {
+        this.title = requestDto.getTitle();
+        this.category = requestDto.getCategory();
+        this.contents = requestDto.getContents();
+        this.mapdata = requestDto.getMapdata();
+        this.address = requestDto.getAddress();
+        this.telNum = requestDto.getTelNum();
+        this.ceo = requestDto.getCeo();
+        this.startTime = requestDto.getStartTime();
+        this.endTime = requestDto.getEndTime();
+        this.closedDay = requestDto.getClosedDay();
+        this.image = image;
+    }
 }

--- a/src/main/java/com/sparta/petplace/post/entity/PostImage.java
+++ b/src/main/java/com/sparta/petplace/post/entity/PostImage.java
@@ -12,7 +12,7 @@ public class PostImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "POST_ID")
     private Post post;
     @Column

--- a/src/main/java/com/sparta/petplace/post/service/PostService.java
+++ b/src/main/java/com/sparta/petplace/post/service/PostService.java
@@ -3,7 +3,9 @@ package com.sparta.petplace.post.service;
 
 import com.sparta.petplace.S3Service;
 import com.sparta.petplace.common.ApiResponseDto;
+import com.sparta.petplace.common.ErrorResponse;
 import com.sparta.petplace.common.ResponseUtils;
+import com.sparta.petplace.common.SuccessResponse;
 import com.sparta.petplace.exception.CustomException;
 import com.sparta.petplace.exception.enumclass.Error;
 import com.sparta.petplace.like.entity.Likes;
@@ -11,7 +13,6 @@ import com.sparta.petplace.like.repository.LikesRepository;
 import com.sparta.petplace.member.entity.LoginType;
 import com.sparta.petplace.member.entity.Member;
 import com.sparta.petplace.member.repository.MemberRepository;
-import com.sparta.petplace.mypage.entity.Mypage;
 import com.sparta.petplace.mypage.repository.MypageRepository;
 import com.sparta.petplace.post.RequestDto.PostRequestDto;
 import com.sparta.petplace.post.ResponseDto.PostResponseDto;
@@ -20,10 +21,10 @@ import com.sparta.petplace.post.entity.PostImage;
 import com.sparta.petplace.post.repository.PostImageRepository;
 import com.sparta.petplace.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.Temporal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +46,7 @@ public class PostService {
         List<Post> posts = postRepository.findAByCategory(keyword);
         List<PostResponseDto> postResponseDtos = new ArrayList<>();
 
-        for (Post p : posts){
+        for (Post p : posts) {
 //            p.getReviews().sort(Comparator.comparing(Review::gerCreatedAt).reversed());
 //            List<ReviewResponseDto> reviewResponseDtos = new ArrayList<>();
 //            for(Review r : p.getReviews()){
@@ -55,31 +56,35 @@ public class PostService {
                     .post(p)
                     .build());
         }
-        return  postResponseDtos;
+        return postResponseDtos;
     }
 
     @Transactional
     public ApiResponseDto<PostResponseDto> createPost(PostRequestDto requestDto, Member member) {
-       Member member1 = memberRepository.findByLoginType(member.getLoginType());
-       if(!member1.getLoginType().equals(LoginType.BUSINESS)) {
-           throw new CustomException(Error.NO_AUTHORITY);
-       }
-        if(requestDto.getImage().isEmpty()){
+        Member member1 = memberRepository.findByLoginType(member.getLoginType());
+        if (!member1.getLoginType().equals(LoginType.BUSINESS)) {
+            throw new CustomException(Error.NO_AUTHORITY);
+        }
+        if (requestDto.getImage().isEmpty()) {
             throw new CustomException(Error.WRONG_INPUT_CONTEN);
+        }
+        if (requestDto.getImage().size() > 4) {
+            throw new RuntimeException("사진은 4개이상 저장할 수 없습니다.");
         }
         Post posts = Post.of(requestDto, member);
         postRepository.save(posts);
         List<String> imgList = new ArrayList<>();
         List<String> img_url = s3Service.upload(requestDto.getImage());
-        for (String image: img_url) {
-            PostImage img = new PostImage(posts,image);
+        for (String image : img_url) {
+            PostImage img = new PostImage(posts, image);
             postImageRepository.save(img);
             imgList.add(image);
         }
         return ResponseUtils.ok(PostResponseDto.from(posts, imgList));
     }
+
     @Transactional
-    public PostResponseDto getPostId(Long post_id, Member member){
+    public PostResponseDto getPostId(Long post_id, Member member) {
         Post posts = postRepository.findById(post_id).orElseThrow(
                 () -> new CustomException(Error.NOT_FOUND_POST)
         );
@@ -94,13 +99,68 @@ public class PostService {
 //            reviewResponseDtos.add(new ReviewResponseDtoa(r));
 //        }
         Likes likes = likesRepository.findByPostIdAndMember(post_id, member);
-        if(likes==null){
-            return PostResponseDto.of(posts ,images,false);
-        }else {
-            return PostResponseDto.of(posts ,images ,true);
+        if (likes == null) {
+            return PostResponseDto.of(posts, images, false);
+        } else {
+            return PostResponseDto.of(posts, images, true);
         }
     }
 
+    @Transactional
+    public ApiResponseDto<?> updatePost(Long post_id, PostRequestDto requestDto, Member member) {
+        Optional<Post> postOptional = postRepository.findById(post_id);
+        //게시글 확인
+        if (postOptional.isEmpty()) {
+            throw new CustomException(Error.NOT_FOUND_POST);
+        }
+        Post post = postOptional.get();
+        if (post.getMember().getEmail().equals(member.getEmail())) {
+            //기존 S3에 저장된 파일을 제거후 다시 저장
+            for (PostImage postImage : post.getImage()) {
+                s3Service.deleteFile(postImage.getImage());
+                postImageRepository.delete(postImage);
+            }
+            //다시 선택한 데이터를 저장, save
+            List<String> imgList = new ArrayList<>();
+            List<String> img_url = s3Service.upload(requestDto.getImage());
+            for (String image : img_url) {
+                PostImage img = new PostImage(post, image);
+                postImageRepository.save(img);
+                imgList.add(image);
+            }
+            //List<String> -> List<PostImage>로 변환
+            List<PostImage> postImages = new ArrayList<>();
+            for (String image : imgList) {
+                PostImage postImage = new PostImage(post, image);
+                postImages.add(postImage);
+            }
+            // Post 객체 업데이트
+            post.update(requestDto, postImages);
+            return ResponseUtils.ok(PostResponseDto.of(post));
+        } else {
+            return ResponseUtils.ok(ErrorResponse.of(HttpStatus.BAD_REQUEST.toString(), "작성자만 게시물을 수정할 수 있습니다."));
+        }
+    }
 
+    @Transactional
+    public ApiResponseDto<SuccessResponse> deletePost(Long post_id, Member member) {
+        Optional<Post> postOptional = postRepository.findById(post_id);
+        if (postOptional.isEmpty()) {
+            throw new CustomException(Error.NOT_FOUND_POST);
+        }
+        Post post = postOptional.get();
+        if (!post.getMember().getEmail().equals(member.getEmail())) {
+            throw new CustomException(Error.NO_AUTHORITY);
+        }
+        //기존 S3에 저장된 파일을 제거후 다시 저장
+        for (PostImage postImage : post.getImage()) {
+            s3Service.deleteFile(postImage.getImage());
+            postImageRepository.delete(postImage);
+        }
+        likesRepository.deleteByPostId(post_id);
+        mypageRepository.deleteByPostId(post_id);
+        postRepository.deleteById(post_id);
+        return ResponseUtils.ok(SuccessResponse.of(HttpStatus.OK, " 게시글 삭제 성공"));
+    }
 
 }


### PR DESCRIPTION
## Feat : 업체등록 게시물 수정 삭제 추가

- S3Service 에 S3에 등록된 게시물을 삭제하는 서비스 로직 추가
- S3파일 삭제중 발생하는 예외 처리위해 enum 추가
- MemberController에서 RequestMapping 부분 제거 API명세서와 동일하게 변경
- PostController에 게시글 수정 삭제 controller 추가
- Post 엔티티에 update 메소드 추가
- Post 삭제 로직에서 연관관계된 like , Mypage 리포지토리에서 제거하는 메소드 추가 

 #26