### PR TITLE
 Feat : 업체등록 게시물 수정 삭제 추가 

### DIFF
--- a/src/main/java/com/sparta/petplace/S3Service.java
+++ b/src/main/java/com/sparta/petplace/S3Service.java
@@ -1,5 +1,6 @@
 package com.sparta.petplace;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
@@ -68,6 +69,25 @@ public class S3Service {
             }
         }
         return imgUrlList;
+    }
+
+    public void deleteFile(String url) {
+        String key = extractKeyFromUrl(url);
+        try {
+            s3Client.deleteObject(bucket, key);
+        } catch (AmazonServiceException e) {
+            throw new CustomException(Error.FAIL_S3_DELETE);
+        }
+    }
+
+    private String extractKeyFromUrl(String url) {
+        // URL에서 파일 키 추출
+        // ex: https://kunon-clean-project.s3.ap-northeast-2.amazonaws.com/post/image/b3dadecf-00a1-4431-bf5a-56c5c04e3624.png
+        String prefix = "https://s3." + region + ".amazonaws.com/" + bucket + "/";
+        if (!url.startsWith(prefix)) {
+            throw new CustomException(Error.FAIL_S3_DELETE);
+        }
+        return url.substring(prefix.length());
     }
 
     // 이미지파일명 중복 방지

--- a/src/main/java/com/sparta/petplace/exception/enumclass/Error.java
+++ b/src/main/java/com/sparta/petplace/exception/enumclass/Error.java
@@ -27,6 +27,7 @@ public enum Error {
 
     // S3
     FAIL_S3_SAVE("400", "S3파일 저장 중 예외 발생"),
+    FAIL_S3_DELETE("400","S3파일 삭제 중 예외 발생"),
     DELETE_S3_FILE("400","s3에 저장되었던 파일 삭제"),
     WRONG_IMAGE_FORMAT("400", "잘못된 포멧입니다."),
     WRONG_INPUT_CONTEN("400", "파일이 존재하지 않습니다."),

--- a/src/main/java/com/sparta/petplace/like/repository/LikesRepository.java
+++ b/src/main/java/com/sparta/petplace/like/repository/LikesRepository.java
@@ -5,7 +5,6 @@ import com.sparta.petplace.member.entity.Member;
 import com.sparta.petplace.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface LikesRepository extends JpaRepository<Likes, Long> {
@@ -13,5 +12,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     Likes findByPostIdAndMember(Long post_id , Member member);
 
-
+    void deleteByPostId(Long postId);
 }
+

--- a/src/main/java/com/sparta/petplace/mypage/repository/MypageRepository.java
+++ b/src/main/java/com/sparta/petplace/mypage/repository/MypageRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface MypageRepository extends JpaRepository<Mypage,Long> {
     List<Mypage> findByMemberId(Long id);
+    void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/sparta/petplace/post/controller/PostController.java
+++ b/src/main/java/com/sparta/petplace/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.sparta.petplace.post.controller;
 
 import com.sparta.petplace.auth.security.UserDetailsImpl;
 import com.sparta.petplace.common.ApiResponseDto;
+import com.sparta.petplace.common.SuccessResponse;
 import com.sparta.petplace.post.RequestDto.PostRequestDto;
 import com.sparta.petplace.post.ResponseDto.PostResponseDto;
 import com.sparta.petplace.post.service.PostService;
@@ -35,6 +36,16 @@ public class PostController {
    @GetMapping("/posts/{post_id}")
    private PostResponseDto getPostId(@PathVariable Long post_id ,@AuthenticationPrincipal UserDetailsImpl userDetails){
       return postService.getPostId(post_id,userDetails.getMember());
+   }
+
+   @PatchMapping("/posts/{post_id}")
+   public ApiResponseDto<?> updePost(@PathVariable Long post_id , PostRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
+      return postService.updatePost(post_id,requestDto,userDetails.getMember());
+   }
+
+   @DeleteMapping("/posts/{post_id}")
+   public ApiResponseDto<SuccessResponse> deletePost(@PathVariable Long post_id, @AuthenticationPrincipal UserDetailsImpl userDetails){
+      return postService.deletePost(post_id, userDetails.getMember());
    }
 
 

--- a/src/main/java/com/sparta/petplace/post/entity/Post.java
+++ b/src/main/java/com/sparta/petplace/post/entity/Post.java
@@ -68,4 +68,18 @@ public class Post extends Timestamped {
                 member(member).
                 build();
     }
+
+    public void update(PostRequestDto requestDto , List<PostImage> image) {
+        this.title = requestDto.getTitle();
+        this.category = requestDto.getCategory();
+        this.contents = requestDto.getContents();
+        this.mapdata = requestDto.getMapdata();
+        this.address = requestDto.getAddress();
+        this.telNum = requestDto.getTelNum();
+        this.ceo = requestDto.getCeo();
+        this.startTime = requestDto.getStartTime();
+        this.endTime = requestDto.getEndTime();
+        this.closedDay = requestDto.getClosedDay();
+        this.image = image;
+    }
 }

--- a/src/main/java/com/sparta/petplace/post/entity/PostImage.java
+++ b/src/main/java/com/sparta/petplace/post/entity/PostImage.java
@@ -12,7 +12,7 @@ public class PostImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "POST_ID")
     private Post post;
     @Column


### PR DESCRIPTION
 Feat : 업체등록 게시물 수정 삭제 추가 

- S3Service 에 S3에 등록된 게시물을 삭제하는 서비스 로직 추가 
- S3파일 삭제중 발생하는 예외 처리위해 enum 추가 
- MemberController에서 RequestMapping 부분 제거 API명세서와 동일하게 변경 
- PostController에 게시글 수정 삭제 controller 추가
- Post 엔티티에 update 메소드 추가 
- Post 삭제 로직에서 연관관계된 like , Mypage 리포지토리에서 제거하는 메소드 추가
-  #26"