### PR TITLE
Fix: refreshToken 생성 메서드 및 조건 변경

### DIFF
--- a/src/main/java/com/sparta/petplace/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/petplace/auth/jwt/JwtUtil.java
@@ -31,7 +31,7 @@ public class JwtUtil {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String REFRESH_TOKEN = "RefreshToken";
     public static final String AUTHORIZATION_KEY = "auth";
-    public static final String BEARER_PREFIX = "Bearer ";
+    private static final String BEARER_PREFIX = "Bearer ";
     private static final long TOKEN_TIME = 60 * 60 * 1000L;
     private static final long REFRESH_TIME = 72 * 60 * 60 * 1000L;
 
@@ -68,11 +68,12 @@ public class JwtUtil {
      *  serialized 객체를 통일해서 보내야함 2진수로 바꿈 (low level)
      *  signature - 내가 발행한 유효한 토큰인지 확인 단방향 암호
      */
-    public TokenDto createAllToken(String email) {
-        return new TokenDto(createToken(email), createRefreshToken());
+    public TokenDto createAllToken(String email,String id) {
+        return new TokenDto(createToken(email), createRefreshToken(id));
     }
     public String createToken(String email) {
         Date date = new Date();
+
 
         return BEARER_PREFIX +
                 Jwts.builder()
@@ -82,11 +83,12 @@ public class JwtUtil {
                         .signWith(key, signatureAlgorithm) // signature - 내가 발행한 유효한 토큰인지 확인 단방향 암호
                         .compact();
     }
-    public String createRefreshToken() {
+    public String createRefreshToken(String id) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()// 토큰안에 정보넣어준것 없어도됨 누구나 decode 가능 base 64
+                        .setSubject(id)
                         .setExpiration(new Date(date.getTime() + REFRESH_TIME)) // serialized 객체를 통일해서 보내야함 2진수로 바꿈 (low level)
                         .setIssuedAt(date)
                         .signWith(key, signatureAlgorithm) // signature - 내가 발행한 유효한 토큰인지 확인 단방향 암호

--- a/src/main/java/com/sparta/petplace/auth/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/petplace/auth/security/UserDetailsServiceImpl.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -21,8 +23,12 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member findMember = memberRepository.findByEmail(email).orElseThrow(
-                () -> new CustomException(Error.NOT_EXIST_USER));
-        return new UserDetailsImpl(findMember, findMember.getEmail());
+        if (memberRepository.findByEmail(email).isPresent()){
+            Member findMember = memberRepository.findByEmail(email).orElseThrow(
+                    () -> new CustomException(Error.NOT_EXIST_USER));
+            return new UserDetailsImpl(findMember, findMember.getEmail());
+        }
+        Optional<Member> findMember = memberRepository.findById(Long.valueOf(email));
+        return new UserDetailsImpl(findMember.get(), findMember.get().getEmail());
     }
 }

--- a/src/main/java/com/sparta/petplace/member/service/KakaoService.java
+++ b/src/main/java/com/sparta/petplace/member/service/KakaoService.java
@@ -55,7 +55,7 @@ public class KakaoService {
         Member member = registerKakaoUserIfNeeded(userInfo);
 
         // 4. JWT 토큰 반환
-        TokenDto tokenDto = jwtUtil.createAllToken(member.getEmail());
+        TokenDto tokenDto = jwtUtil.createAllToken(member.getEmail(), String.valueOf(member.getId()));
 
         //  Member Email값으로 refreshToken을 찾는다
         Optional<RefreshToken> refreshToken = refreshTokenRepository.findAllByMemberId(member.getEmail());

--- a/src/main/java/com/sparta/petplace/member/service/MemberService.java
+++ b/src/main/java/com/sparta/petplace/member/service/MemberService.java
@@ -21,6 +21,7 @@ import com.sparta.petplace.member.repository.MemberRepository;
 import com.sparta.petplace.post.ResponseDto.HistoryPostResponseDto;
 import com.sparta.petplace.post.entity.Post;
 import com.sparta.petplace.post.repository.PostRepository;
+import com.sparta.petplace.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static com.sparta.petplace.exception.Error.NOT_EXIST_USER;
+import static com.sparta.petplace.exception.Error.PASSWORD_WRONG;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -42,9 +46,9 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
-
     private final PasswordEncoder passwordEncoder;
     private final MemberHistoryRepository memberHistoryRepository;
+    private final PostService postService;
     private final PostRepository postRepository;
 
 
@@ -88,10 +92,10 @@ public class MemberService {
         Optional<Member> findMember = memberRepository.findByEmail(email);
 
         if (findMember.isEmpty()) {
-            throw new CustomException(Error.NOT_EXIST_USER);
+            throw new CustomException(NOT_EXIST_USER);
         }
         if (!passwordEncoder.matches(password, findMember.get().getPassword())) {
-            throw new CustomException(Error.PASSWORD_WRONG);
+            throw new CustomException(PASSWORD_WRONG);
         }
         // Token 생성
         TokenDto tokenDto = jwtUtil.createAllToken(email);


### PR DESCRIPTION
RefreshToken으로 accessToken을 새롭게 갱신할때 RefreshToken 에 email값이 담겨있어 문제가 된다고 판단.
RefreshToken 에 email값을 제외하고 accessToken을 갱신할 수 있도록 변경